### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
-        "illuminate/validation": "^10|^11|^12"
+        "illuminate/validation": "^10|^11|^12|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.